### PR TITLE
Ensure thread-safe task queue operations

### DIFF
--- a/app/client/tests.py
+++ b/app/client/tests.py
@@ -213,9 +213,10 @@ class TestMultithreadedClient(BaseTestClient):
             print(f"{thread_id=} started")
             print(f"{runner_id=} start")
             for i in range(1):
-                self.client.add_task(1, runner_id * 100 + i, 60.0, 162030.0)
-                self.client.get_task(1, i)
-                self.client.delete_task(1, runner_id * 100 + i)
+                task_id = runner_id * 100 + i
+                self.client.add_task(1, task_id, 60.0, 162030.0)
+                self.client.get_task(1, task_id)
+                self.client.delete_task(1, task_id)
             print(f"{runner_id=} done")
 
         futures = []

--- a/app/task_queue/manager.py
+++ b/app/task_queue/manager.py
@@ -1,32 +1,37 @@
+import threading
+
 from .queue import TaskQueue
 
 
 class QueueManager:
     _queues: dict[int, TaskQueue] = {}
+    _lock = threading.Lock()
 
     @classmethod
     def get_queue(cls, employer_id: int) -> TaskQueue:
-        queue = cls._queues.get(employer_id, None)
-        if queue is None:
-            raise ValueError(f"No queue for employer_id {employer_id}")
-        return queue
+        with cls._lock:
+            queue = cls._queues.get(employer_id, None)
+            if queue is None:
+                raise ValueError(f"No queue for employer_id {employer_id}")
+            return queue
 
     @classmethod
     def create_queue(cls, employer_id: int) -> TaskQueue:
-        if employer_id in cls._queues:
-            raise ValueError(f"Queue for employer_id {employer_id} already exists")
-
-        queue = TaskQueue()
-        cls._queues[employer_id] = queue
-        return queue
+        with cls._lock:
+            if employer_id in cls._queues:
+                raise ValueError(f"Queue for employer_id {employer_id} already exists")
+            queue = TaskQueue()
+            cls._queues[employer_id] = queue
+            return queue
 
     @classmethod
     def delete_queue(cls, employer_id: int):
-        if employer_id not in cls._queues:
-            raise ValueError(f"No queue for employer_id {employer_id}")
-
-        del cls._queues[employer_id]
+        with cls._lock:
+            if employer_id not in cls._queues:
+                raise ValueError(f"No queue for employer_id {employer_id}")
+            del cls._queues[employer_id]
 
     @classmethod
     def clear(cls):
-        cls._queues.clear()
+        with cls._lock:
+            cls._queues.clear()


### PR DESCRIPTION
## Summary
- protect client protocol usage with an RLock
- add synchronization to task queue and queue manager
- fix multithreaded client test

## Testing
- `ruff check app/client/tests.py app/client/client.py app/task_queue/queue.py app/task_queue/manager.py`
- `PYTHONPATH=app python -m tests`


------
https://chatgpt.com/codex/tasks/task_e_68946ba9a5e88326859074f9176d1ade