### PR TITLE
Fix base handler not implemented error

### DIFF
--- a/app/server/handlers/base_handler.py
+++ b/app/server/handlers/base_handler.py
@@ -3,4 +3,4 @@ class BaseHandler:
         self.session = session
 
     def handle(self):
-        raise NotImplemented("Method not implemented")
+        raise NotImplementedError("Method not implemented")


### PR DESCRIPTION
## Summary
- replace `NotImplemented` with `NotImplementedError` in base handler

## Testing
- `ruff check` (fails: Found 415 errors)
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68947fea0604832685558d3a05c2e888