### PR TITLE
refactor get_tasks to yield

### DIFF
--- a/app/task_queue/queue.py
+++ b/app/task_queue/queue.py
@@ -122,19 +122,13 @@ class TaskQueue:
             self._first.prev = task
         self._first = task
 
-    def get_tasks(self, from_task: TaskNode = None, to_task: TaskNode = None) -> Iterator[TaskNode]:
+    def get_tasks(self, from_task: TaskNode | None = None, to_task: TaskNode | None = None) -> Iterator[TaskNode]:
         with self._lock:
             current = from_task or self._first
-            if not current:
-                return []
-
-            tasks = []
-            while True:
-                tasks.append(current)
-                if current == to_task or current == self._last or current.next is None:
-                    break
+            after = to_task.next if to_task else None
+            while current and current is not after:
+                yield current
                 current = current.next
-            return iter(tasks)
 
     @property
     def first_task(self) -> Optional[TaskNode]:


### PR DESCRIPTION
## Summary
- refactor TaskQueue.get_tasks to yield items instead of building a list

## Testing
- `ruff check` *(fails: ANN002 Missing type annotation for `*args`, ANN003 Missing type annotation for `**kwargs`, ANN204 Missing return type annotation for special method `__init__`, ANN201 Missing return type annotation for public function `set`, ANN201 Missing return type annotation for public function `delete`, UP045 Use `X | None` for type annotations, ANN204 Missing return type annotation for special method `__init__`, ANN201 Missing return type annotation for public function `add_task`, UP045 Use `X | None` for type annotations, ANN201 Missing return type annotation for public function `unlink_task`, UP045 Use `X | None` for type annotations, ANN002 Missing type annotation for `*args`, ANN003 Missing type annotation for `**kwargs`, ANN204 Missing return type annotation for special method `__iadd__`, ANN001 Missing type annotation for function argument `handler`, ANN204 Missing return type annotation for special method `__isub__`, ANN001 Missing type annotation for function argument `handler`, ANN204 Missing return type annotation for special method `__call__`, ANN002 Missing type annotation for `*args`, ANN003 Missing type annotation for `**kwargs`, E722 Do not use bare `except`, S110 `try`-`except`-`pass` detected)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689480580db88326a11558803a637c81