### PR TITLE
Add optional ruff check to workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,23 @@ on:
   pull_request:
 
 jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    defaults:
+      run:
+        working-directory: app
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install Poetry
+        run: pip install poetry
+      - name: Install dependencies
+        run: poetry install --no-interaction
+      - name: Ruff check
+        run: poetry run ruff check
   tests:
     runs-on: ubuntu-latest
     defaults:


### PR DESCRIPTION
## Summary
- add ruff check to CI without failing PR

## Testing
- `poetry run ruff check`
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894837693a48326a25c06058d78646b